### PR TITLE
Fixes for PrayerSwap and GearSwapper

### DIFF
--- a/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/GearSwapper.java
+++ b/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/GearSwapper.java
@@ -172,7 +172,7 @@ public class GearSwapper extends Plugin
 			return;
 		}
 
-		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 3)
+		if (client.getVar(VarClientInt.PLAYER_INTERFACE_CONTAINER_OPENED) != 3)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.INVENTORY, client));
 			flexo.delay(25);
@@ -197,7 +197,7 @@ public class GearSwapper extends Plugin
 			return;
 		}
 
-		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 4)
+		if (client.getVar(VarClientInt.PLAYER_INTERFACE_CONTAINER_OPENED) != 4)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.EQUIPMENT, client));
 			flexo.delay(35);
@@ -219,14 +219,14 @@ public class GearSwapper extends Plugin
 	{
 		equipItem(equip);
 
-		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 4 && remove.size() > 0)
+		if (client.getVar(VarClientInt.PLAYER_INTERFACE_CONTAINER_OPENED) != 4 && remove.size() > 0)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.EQUIPMENT, client));
 		}
 
 		removeItem(remove);
 
-		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 3)
+		if (client.getVar(VarClientInt.PLAYER_INTERFACE_CONTAINER_OPENED) != 3)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.INVENTORY, client));
 		}

--- a/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/GearSwapper.java
+++ b/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/GearSwapper.java
@@ -182,10 +182,6 @@ public class GearSwapper extends Plugin
 		{
 			if (item != null)
 			{
-				if (itemManager.getItemDefinition(item.getId()) != null)
-				{
-					log.info("Grabbing Bounds and CP of: " + itemManager.getItemDefinition(item.getId()).getName());
-				}
 				if (item.getCanvasBounds() != null)
 				{
 					ExtUtils.handleSwitch(item.getCanvasBounds(), config.actionType(), flexo, client, scalingfactor, (int) getMillis());
@@ -211,10 +207,6 @@ public class GearSwapper extends Plugin
 		{
 			if (item != null)
 			{
-				if (itemManager.getItemDefinition(item.getItemId()) != null)
-				{
-					log.info("Grabbing Bounds and CP of: " + itemManager.getItemDefinition(item.getId()).getName());
-				}
 				if (item.getBounds() != null)
 				{
 					ExtUtils.handleSwitch(item.getBounds(), config.actionType(), flexo, client, scalingfactor, (int) getMillis());

--- a/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/GearSwapper.java
+++ b/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/GearSwapper.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.VarClientInt;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -171,7 +172,7 @@ public class GearSwapper extends Plugin
 			return;
 		}
 
-		if (client.getWidget(WidgetInfo.INVENTORY).isHidden())
+		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 3)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.INVENTORY, client));
 			flexo.delay(25);
@@ -200,7 +201,7 @@ public class GearSwapper extends Plugin
 			return;
 		}
 
-		if (client.getWidget(WidgetInfo.EQUIPMENT).isHidden())
+		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 4)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.EQUIPMENT, client));
 			flexo.delay(35);
@@ -226,14 +227,14 @@ public class GearSwapper extends Plugin
 	{
 		equipItem(equip);
 
-		if (client.getWidget(WidgetInfo.EQUIPMENT).isHidden() && remove.size() > 0)
+		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 4 && remove.size() > 0)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.EQUIPMENT, client));
 		}
 
 		removeItem(remove);
 
-		if (client.getWidget(WidgetInfo.INVENTORY).isHidden())
+		if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 3)
 		{
 			flexo.keyPress(TabUtils.getTabHotkey(Tab.INVENTORY, client));
 		}

--- a/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/utils/ExtUtils.java
+++ b/GearSwapper/src/main/java/net/runelite/client/plugins/gearswapper/utils/ExtUtils.java
@@ -89,7 +89,8 @@ public class ExtUtils
 			{
 				case FLEXO:
 					flexo.mouseMove(cp.getX(), cp.getY());
-					flexo.mousePressAndRelease(1);
+					flexo.delay(delay);
+					leftClickAndRelease(client, scalingfactor);
 					break;
 				case MOUSEEVENTS:
 					leftClick(cp.getX(), cp.getY(), client, scalingfactor);
@@ -101,13 +102,18 @@ public class ExtUtils
 
 	public static void leftClick(int x, int y, Client client, double scalingFactor)
 	{
+		net.runelite.api.Point p = client.getMouseCanvasPosition();
+		if (p.getX() != x || p.getY() != y)
+		{
+			moveMouse(x, y, client);
+		}
+		leftClickAndRelease(client, scalingFactor);
+	}
+
+	private static void leftClickAndRelease(Client client, double scalingFactor)
+	{
 		if (client.isStretchedEnabled())
 		{
-			net.runelite.api.Point p = client.getMouseCanvasPosition();
-			if (p.getX() != x || p.getY() != y)
-			{
-				moveMouse(x, y, client);
-			}
 			double scale = 1 + (scalingFactor / 100);
 
 			MouseEvent mousePressed =
@@ -120,13 +126,8 @@ public class ExtUtils
 				new MouseEvent(client.getCanvas(), 500, System.currentTimeMillis(), 0, (int) (client.getMouseCanvasPosition().getX() * scale), (int) (client.getMouseCanvasPosition().getY() * scale), 1, false, 1);
 			client.getCanvas().dispatchEvent(mouseClicked);
 		}
-		if (!client.isStretchedEnabled())
+		else
 		{
-			net.runelite.api.Point p = client.getMouseCanvasPosition();
-			if (p.getX() != x || p.getY() != y)
-			{
-				moveMouse(x, y, client);
-			}
 			MouseEvent mousePressed = new MouseEvent(client.getCanvas(), 501, System.currentTimeMillis(), 0, client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY(), 1, false, 1);
 			client.getCanvas().dispatchEvent(mousePressed);
 			MouseEvent mouseReleased = new MouseEvent(client.getCanvas(), 502, System.currentTimeMillis(), 0, client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY(), 1, false, 1);

--- a/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
+++ b/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
@@ -318,7 +318,8 @@ public class PraySwap extends Plugin
 			{
 				case FLEXO:
 					flexo.mouseMove(cp.getX(), cp.getY());
-					flexo.mousePressAndRelease(1);
+					this.delay();
+					this.leftClickAndRelease();
 					flexo.delay(10);
 					if (swapBack && config.backToInventory())
 					{
@@ -361,14 +362,19 @@ public class PraySwap extends Plugin
 
 	private void leftClick(int x, int y)
 	{
+		Point p = this.client.getMouseCanvasPosition();
+		if (p.getX() != x || p.getY() != y)
+		{
+			this.moveMouse(x, y);
+		}
+		this.leftClickAndRelease();
+	}
+
+	private void leftClickAndRelease()
+	{
 		if (client.isStretchedEnabled())
 		{
 			double scalingfactor = configManager.getConfig(StretchedModeConfig.class).scalingFactor();
-			Point p = this.client.getMouseCanvasPosition();
-			if (p.getX() != x || p.getY() != y)
-			{
-				this.moveMouse(x, y);
-			}
 			double scale = 1 + (scalingfactor / 100);
 
 			MouseEvent mousePressed =
@@ -383,17 +389,24 @@ public class PraySwap extends Plugin
 		}
 		else
 		{
-			Point p = this.client.getMouseCanvasPosition();
-			if (p.getX() != x || p.getY() != y)
-			{
-				this.moveMouse(x, y);
-			}
 			MouseEvent mousePressed = new MouseEvent(this.client.getCanvas(), 501, System.currentTimeMillis(), 0, this.client.getMouseCanvasPosition().getX(), this.client.getMouseCanvasPosition().getY(), 1, false, 1);
 			this.client.getCanvas().dispatchEvent(mousePressed);
 			MouseEvent mouseReleased = new MouseEvent(this.client.getCanvas(), 502, System.currentTimeMillis(), 0, this.client.getMouseCanvasPosition().getX(), this.client.getMouseCanvasPosition().getY(), 1, false, 1);
 			this.client.getCanvas().dispatchEvent(mouseReleased);
 			MouseEvent mouseClicked = new MouseEvent(this.client.getCanvas(), 500, System.currentTimeMillis(), 0, this.client.getMouseCanvasPosition().getX(), this.client.getMouseCanvasPosition().getY(), 1, false, 1);
 			this.client.getCanvas().dispatchEvent(mouseClicked);
+		}
+	}
+
+	private void delay()
+	{
+		try
+		{
+			Thread.sleep(getMillis());
+		}
+		catch (InterruptedException e)
+		{
+			e.printStackTrace();
 		}
 	}
 

--- a/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
+++ b/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
@@ -50,6 +50,7 @@ import net.runelite.client.plugins.PluginType;
 import net.runelite.client.plugins.prayswap.utils.Tab;
 import net.runelite.client.plugins.prayswap.utils.TabUtils;
 import net.runelite.client.plugins.stretchedmode.StretchedModeConfig;
+import net.runelite.api.VarClientInt;
 
 @PluginDescriptor(
 	name = "PraySwap",
@@ -218,7 +219,7 @@ public class PraySwap extends Plugin implements KeyListener
 
 			if (widget != null)
 			{
-				if (widget.isHidden())
+				if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 5)
 				{
 					flexo.keyPress(tabUtils.getTabHotkey(Tab.PRAYER));
 				}

--- a/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
+++ b/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
@@ -300,7 +300,7 @@ public class PraySwap extends Plugin
 
 			if (widget != null)
 			{
-				if (client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) != 5)
+				if (client.getVar(VarClientInt.PLAYER_INTERFACE_CONTAINER_OPENED) != 5)
 				{
 					flexo.keyPress(tabUtils.getTabHotkey(Tab.PRAYER));
 				}

--- a/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
+++ b/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
@@ -37,6 +37,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
+import net.runelite.api.VarClientInt;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.Keybind;
@@ -52,7 +53,6 @@ import net.runelite.client.plugins.prayswap.utils.Tab;
 import net.runelite.client.plugins.prayswap.utils.TabUtils;
 import net.runelite.client.plugins.stretchedmode.StretchedModeConfig;
 import net.runelite.client.util.HotkeyListener;
-import net.runelite.api.VarClientInt;
 
 @PluginDescriptor(
 	name = "PraySwap",

--- a/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
+++ b/PraySwapper/src/main/java/net/runelite/client/plugins/prayswap/PraySwap.java
@@ -39,6 +39,7 @@ import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.config.Keybind;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.flexo.Flexo;
@@ -50,6 +51,7 @@ import net.runelite.client.plugins.PluginType;
 import net.runelite.client.plugins.prayswap.utils.Tab;
 import net.runelite.client.plugins.prayswap.utils.TabUtils;
 import net.runelite.client.plugins.stretchedmode.StretchedModeConfig;
+import net.runelite.client.util.HotkeyListener;
 import net.runelite.api.VarClientInt;
 
 @PluginDescriptor(
@@ -59,7 +61,7 @@ import net.runelite.api.VarClientInt;
 	type = PluginType.EXTERNAL
 )
 
-public class PraySwap extends Plugin implements KeyListener
+public class PraySwap extends Plugin
 {
 	@Inject
 	private Client client;
@@ -77,6 +79,16 @@ public class PraySwap extends Plugin implements KeyListener
 	private ThreadPoolExecutor executorService = new ThreadPoolExecutor(1, 1, 1, TimeUnit.SECONDS, queue,
 		new ThreadPoolExecutor.DiscardPolicy());
 	private Flexo flexo;
+	private Keybind mageKey;
+	private Keybind rangeKey;
+	private Keybind meleeKey;
+	private Keybind auguryKey;
+	private Keybind rigourKey;
+	private Keybind pietyKey;
+	private Keybind smiteKey;
+	private Keybind comboOneKey;
+	private Keybind comboTwoKey;
+	private Keybind comboThreeKey;
 
 	@Provides
 	PraySwapConfig getConfig(ConfigManager manager)
@@ -87,7 +99,19 @@ public class PraySwap extends Plugin implements KeyListener
 	protected void startUp()
 	{
 		eventBus.subscribe(GameTick.class, this, this::onGameTick);
-		keyManager.registerKeyListener(this);
+
+		this.updateConfig();
+		keyManager.registerKeyListener(mageKeyListener);
+		keyManager.registerKeyListener(rangeKeyListener);
+		keyManager.registerKeyListener(meleeKeyListener);
+		keyManager.registerKeyListener(auguryKeyListener);
+		keyManager.registerKeyListener(rigourKeyListener);
+		keyManager.registerKeyListener(pietyKeyListener);
+		keyManager.registerKeyListener(smiteKeyListener);
+		keyManager.registerKeyListener(comboOneKeyListener);
+		keyManager.registerKeyListener(comboTwoKeyListener);
+		keyManager.registerKeyListener(comboThreeKeyListener);
+
 		Flexo.client = client;
 		executorService.submit(() -> {
 			flexo = null;
@@ -104,10 +128,18 @@ public class PraySwap extends Plugin implements KeyListener
 
 	protected void shutDown()
 	{
-		keyManager.unregisterKeyListener(this);
+		keyManager.unregisterKeyListener(mageKeyListener);
+		keyManager.unregisterKeyListener(rangeKeyListener);
+		keyManager.unregisterKeyListener(meleeKeyListener);
+		keyManager.unregisterKeyListener(auguryKeyListener);
+		keyManager.unregisterKeyListener(rigourKeyListener);
+		keyManager.unregisterKeyListener(pietyKeyListener);
+		keyManager.unregisterKeyListener(smiteKeyListener);
+		keyManager.unregisterKeyListener(comboOneKeyListener);
+		keyManager.unregisterKeyListener(comboTwoKeyListener);
+		keyManager.unregisterKeyListener(comboThreeKeyListener);
 		eventBus.unregister(this);
 	}
-
 
 	private void onGameTick(GameTick event)
 	{
@@ -117,27 +149,37 @@ public class PraySwap extends Plugin implements KeyListener
 		}
 	}
 
-	@Override
-	public void keyTyped(KeyEvent e)
+	private final HotkeyListener mageKeyListener = new HotkeyListener(() -> this.mageKey)
 	{
-	}
-
-	@Override
-	public void keyPressed(KeyEvent e)
-	{
-		if (e.getKeyCode() == config.hotkeyMage().getKeyCode())
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> clickPrayer(Prayer.PROTECT_FROM_MAGIC, true));
 		}
-		if (e.getKeyCode() == config.hotkeyRange().getKeyCode())
+	};
+
+	private final HotkeyListener rangeKeyListener = new HotkeyListener(() -> this.rangeKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> clickPrayer(Prayer.PROTECT_FROM_MISSILES, true));
 		}
-		if (e.getKeyCode() == config.hotkeyMelee().getKeyCode())
+	};
+
+	private final HotkeyListener meleeKeyListener = new HotkeyListener(() -> this.meleeKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> clickPrayer(Prayer.PROTECT_FROM_MELEE, true));
 		}
-		if (e.getKeyCode() == config.hotkeyAugury().getKeyCode())
+	};
+
+	private final HotkeyListener auguryKeyListener = new HotkeyListener(() -> this.auguryKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			if (config.lowLevel())
 			{
@@ -148,7 +190,12 @@ public class PraySwap extends Plugin implements KeyListener
 				executorService.submit(() -> clickPrayer(Prayer.AUGURY, true));
 			}
 		}
-		if (e.getKeyCode() == config.hotkeyRigour().getKeyCode())
+	};
+
+	private final HotkeyListener rigourKeyListener = new HotkeyListener(() -> this.rigourKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			if (config.lowLevel())
 			{
@@ -159,7 +206,12 @@ public class PraySwap extends Plugin implements KeyListener
 				executorService.submit(() -> clickPrayer(Prayer.RIGOUR, true));
 			}
 		}
-		if (e.getKeyCode() == config.hotkeyPiety().getKeyCode())
+	};
+
+	private final HotkeyListener pietyKeyListener = new HotkeyListener(() -> this.pietyKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			if (config.lowLevel())
 			{
@@ -174,36 +226,65 @@ public class PraySwap extends Plugin implements KeyListener
 				executorService.submit(() -> clickPrayer(Prayer.PIETY, true));
 			}
 		}
-		if (e.getKeyCode() == config.hotkeySmite().getKeyCode())
+	};
+
+	private final HotkeyListener smiteKeyListener = new HotkeyListener(() -> this.smiteKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> clickPrayer(Prayer.SMITE, true));
 		}
-		if (e.getKeyCode() == config.comboOne().getKeyCode())
+	};
+
+	private final HotkeyListener comboOneKeyListener = new HotkeyListener(() -> this.comboOneKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> {
 				clickPrayer(config.comboOnePrayerOne().getPrayer(), false);
 				clickPrayer(config.comboOnePrayerTwo().getPrayer(), true);
 			});
 		}
-		if (e.getKeyCode() == config.comboTwo().getKeyCode())
+	};
+
+	private final HotkeyListener comboTwoKeyListener = new HotkeyListener(() -> this.comboTwoKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> {
 				clickPrayer(config.comboTwoPrayerOne().getPrayer(), false);
 				clickPrayer(config.comboTwoPrayerTwo().getPrayer(), true);
 			});
 		}
-		if (e.getKeyCode() == config.comboThree().getKeyCode())
+	};
+
+	private final HotkeyListener comboThreeKeyListener = new HotkeyListener(() -> this.comboThreeKey)
+	{
+		@Override
+		public void hotkeyPressed()
 		{
 			executorService.submit(() -> {
 				clickPrayer(config.comboThreePrayerOne().getPrayer(), false);
 				clickPrayer(config.comboThreePrayerTwo().getPrayer(), true);
 			});
 		}
-	}
+	};
 
-	@Override
-	public void keyReleased(KeyEvent e)
+	private void updateConfig()
 	{
+		this.mageKey = config.hotkeyMage();
+		this.rangeKey = config.hotkeyRange();
+		this.meleeKey = config.hotkeyMelee();
+		this.auguryKey = config.hotkeyAugury();
+		this.rigourKey = config.hotkeyRigour();
+		this.pietyKey = config.hotkeyPiety();
+		this.smiteKey = config.hotkeySmite();
+		this.comboOneKey = config.comboOne();
+		this.comboTwoKey = config.comboTwo();
+		this.comboThreeKey = config.comboThree();
 	}
 
 	private boolean shouldProtPray()


### PR DESCRIPTION
The `widget.isHidden()` check silently blows things up (as we discussed in discord), so change how it checks for which interface is open/closed.

Use the same key listener setup found in the world hopper plugin since it handles key combinations correctly.

Use MouseEvents to do the actual clicking. Using the flexo mouse clicker fails to actually click, and then adds weird ghost movements after the normal movement finishes. By switching to mouseevents (for clicking only), the whole thing works perfectly and smoothly.

Question for you: is the use of mouseevents ok here? is there any fuzzing that flexo mouse does that should be replicated here?