### PR TITLE
autoprayflick: removed unused local variables

### DIFF
--- a/AutoPrayFlick/src/main/java/net/runelite/client/plugins/externals/autoprayflick/AutoPrayFlickOverlay.java
+++ b/AutoPrayFlick/src/main/java/net/runelite/client/plugins/externals/autoprayflick/AutoPrayFlickOverlay.java
@@ -73,9 +73,6 @@ class AutoPrayFlickOverlay extends Overlay
 			return null;
 		}
 
-		int orbInnerHeight = (int) bounds.getHeight();
-		int orbInnerWidth = orbInnerHeight;
-
 		int orbInnerX = (int) (bounds.getX() + 24);//x pos of the inside of the prayer orb
 		int orbInnerY = (int) (bounds.getY() - 1);//y pos of the inside of the prayer orb
 


### PR DESCRIPTION
There are two unused local variables. I removed unused local variables.

This commitment supports to open source community for **Hacktoberfest**.