### PR TITLE
AutoClicker - Lower min HP range on auto disable

### DIFF
--- a/AutoClicker/src/main/java/net/runelite/client/plugins/externals/autoclicker/AutoClickConfig.java
+++ b/AutoClicker/src/main/java/net/runelite/client/plugins/externals/autoclicker/AutoClickConfig.java
@@ -128,7 +128,7 @@ public interface AutoClickConfig extends Config
 	}
 
 	@Range(
-		min = 5,
+		min = 2,
 		max = 98
 	)
 	@ConfigItem(


### PR DESCRIPTION
Lower HP range down to 2 from 5, to better suit lower HP accounts